### PR TITLE
return 401 instead of 403 on missing token

### DIFF
--- a/project/server/auth/views.py
+++ b/project/server/auth/views.py
@@ -169,7 +169,7 @@ class LogoutAPI(MethodView):
                 'status': 'fail',
                 'message': 'Provide a valid auth token.'
             }
-            return make_response(jsonify(responseObject)), 403
+            return make_response(jsonify(responseObject)), 401
 
 # define the API resources
 registration_view = RegisterAPI.as_view('register_api')


### PR DESCRIPTION
I've been poking around on auth error codes (401 vs 403) and I _think_ that 403 is used specifically for "you don't have sufficient privileges". Ie, "you're requesting an admin resource but you're only a piddly user". So TMK where we're lacking an `auth_token`, it should still be a 401. Feel free to close if I'm wrong